### PR TITLE
Propagate error event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 npm-debug.log
 node_modules/
 test/tmp/

--- a/lib/lazystream.js
+++ b/lib/lazystream.js
@@ -29,7 +29,10 @@ function Readable(fn, options) {
 
   beforeFirstCall(this, '_read', function() {
     var source = fn.call(this, options);
-    var that = this;
+    var that = this
+    source.on('error', function(err) {
+      that.emit('error', err)
+    })
     source.pipe(this);
   });
 
@@ -44,6 +47,10 @@ function Writable(fn, options) {
 
   beforeFirstCall(this, '_write', function() {
     var destination = fn.call(this, options);
+    var that = this
+    destination.on('error', function(err) {
+      that.emit('error', err)
+    })
     this.pipe(destination);
   });
 


### PR DESCRIPTION
As the title says. This is actually very important, because if no error handlers are defined on the wrapped stream, an exception will be thrown in case of an error event.
Cheers!
