### PR TITLE
fix(readable-stream): access via dot-notation

### DIFF
--- a/lib/lazystream.js
+++ b/lib/lazystream.js
@@ -1,5 +1,5 @@
 var util = require('util');
-var PassThrough = require('readable-stream/passthrough');
+var PassThrough = require('readable-stream').PassThrough;
 
 module.exports = {
   Readable: Readable,


### PR DESCRIPTION
fixed PassThrough import error for modern node implementations 